### PR TITLE
PR : NaverOauth2 기능 완성

### DIFF
--- a/src/main/java/fivestar/kTour/controller/OauthController.java
+++ b/src/main/java/fivestar/kTour/controller/OauthController.java
@@ -1,26 +1,41 @@
 package fivestar.kTour.controller;
 
 import fivestar.kTour.Dto.LoginResponseDto;
+import fivestar.kTour.oauth.KakaoOauthLoginParam;
+import fivestar.kTour.oauth.NaverOauthLoginParam;
 import fivestar.kTour.service.OauthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
 public class OauthController {
 
-    private final OauthService kakaoOauthService;
+    private final OauthService<KakaoOauthLoginParam> kakaoOauthService;
+    private final OauthService<NaverOauthLoginParam> naverOauthService;
 
     /**
      * OAuth 로그인 시 인증 코드를 넘겨받은 후 첫 로그인 시 회원 가입
      */
     @GetMapping("/oauth/{provider}")
-    public ResponseEntity<LoginResponseDto> kakaoCallback(@PathVariable String provider, @RequestParam String code) {
+    public ResponseEntity<LoginResponseDto> oauthCallback(@PathVariable String provider,
+                                                          @RequestParam String code,
+                                                          @RequestParam(required = false) String state) {
         log.info("code={}", code);
-        LoginResponseDto res = kakaoOauthService.login(provider, code);
-        return ResponseEntity.ok().body(res);
+        if(provider.equals("kakao")) {
+            LoginResponseDto res = kakaoOauthService.login(new KakaoOauthLoginParam(provider, code));
+            return ResponseEntity.ok().body(res);
+        }
+        if(provider.equals("naver")) {
+            LoginResponseDto res = naverOauthService.login(new NaverOauthLoginParam(provider, code, state));
+            return ResponseEntity.ok().body(res);
+        }
+        throw new IllegalArgumentException("oauth2 provider must be naver or kakao");
     }
 }

--- a/src/main/java/fivestar/kTour/oauth/KakaoOauthLoginParam.java
+++ b/src/main/java/fivestar/kTour/oauth/KakaoOauthLoginParam.java
@@ -1,0 +1,4 @@
+package fivestar.kTour.oauth;
+
+public record KakaoOauthLoginParam(String provider, String code) {
+}

--- a/src/main/java/fivestar/kTour/oauth/KakaoUserInfo.java
+++ b/src/main/java/fivestar/kTour/oauth/KakaoUserInfo.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public class KakaoUserInfo implements Oauth2UserInfo {
 
-    private Map<String, Object> attributes;
+    private final Map<String, Object> attributes;
 
     public KakaoUserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;

--- a/src/main/java/fivestar/kTour/oauth/NaverOauthLoginParam.java
+++ b/src/main/java/fivestar/kTour/oauth/NaverOauthLoginParam.java
@@ -1,0 +1,4 @@
+package fivestar.kTour.oauth;
+
+public record NaverOauthLoginParam(String provider, String code, String state) {
+}

--- a/src/main/java/fivestar/kTour/oauth/NaverUserInfo.java
+++ b/src/main/java/fivestar/kTour/oauth/NaverUserInfo.java
@@ -1,0 +1,46 @@
+package fivestar.kTour.oauth;
+
+import java.util.Map;
+
+public class NaverUserInfo implements Oauth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(getResponse().get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) getResponse().get("email");
+    }
+
+    @Override
+    public String getNickName() {
+        return (String) getResponse().get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) getResponse().get("profile_image");
+    }
+
+    @Override
+    public String getAgeRange() {
+        return (String) getResponse().get("age");
+    }
+
+    public Map<String, Object> getResponse() {
+        return (Map<String, Object>) attributes.get("response");
+    }
+}

--- a/src/main/java/fivestar/kTour/service/KakaoOauthService.java
+++ b/src/main/java/fivestar/kTour/service/KakaoOauthService.java
@@ -3,6 +3,7 @@ package fivestar.kTour.service;
 import fivestar.kTour.Dto.LoginResponseDto;
 import fivestar.kTour.Dto.OauthTokenResponseDto;
 import fivestar.kTour.domain.User;
+import fivestar.kTour.oauth.KakaoOauthLoginParam;
 import fivestar.kTour.oauth.KakaoUserInfo;
 import fivestar.kTour.oauth.Oauth2UserInfo;
 import fivestar.kTour.repository.UserRepository;
@@ -27,7 +28,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class KakaoOauthService implements OauthService {
+public class KakaoOauthService implements OauthService<KakaoOauthLoginParam> {
 
     private final UserRepository userRepository;
     private final InMemoryClientRegistrationRepository inMemoryRepository;
@@ -41,13 +42,14 @@ public class KakaoOauthService implements OauthService {
      */
 
     @Transactional
-    public LoginResponseDto login(String providerName, String code) {
+    @Override
+    public LoginResponseDto login(KakaoOauthLoginParam params) {
 
-        ClientRegistration provider = inMemoryRepository.findByRegistrationId(providerName);
+        ClientRegistration provider = inMemoryRepository.findByRegistrationId(params.provider());
         log.info("redirect uri = {}", provider.getRedirectUri());
-        OauthTokenResponseDto tokenResponse = getToken(code, provider);
+        OauthTokenResponseDto tokenResponse = getToken(params.code(), provider);
         log.info("OauthAccessToken = {}", tokenResponse.access_token());
-        User user = getUserProfile(providerName, tokenResponse, provider);
+        User user = getUserProfile(params.provider(), tokenResponse, provider);
 
         String accessToken = tokenService.generateToken(user.getUserEmail());
         log.info("ServerAccessToken={}", accessToken);

--- a/src/main/java/fivestar/kTour/service/NaverOauthService.java
+++ b/src/main/java/fivestar/kTour/service/NaverOauthService.java
@@ -1,0 +1,126 @@
+package fivestar.kTour.service;
+
+import fivestar.kTour.Dto.LoginResponseDto;
+import fivestar.kTour.Dto.OauthTokenResponseDto;
+import fivestar.kTour.domain.User;
+import fivestar.kTour.oauth.NaverOauthLoginParam;
+import fivestar.kTour.oauth.NaverUserInfo;
+import fivestar.kTour.oauth.Oauth2UserInfo;
+import fivestar.kTour.repository.UserRepository;
+import fivestar.kTour.security.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NaverOauthService implements OauthService<NaverOauthLoginParam> {
+
+    private final UserRepository userRepository;
+    private final InMemoryClientRegistrationRepository inMemoryRepository;
+    private final TokenService tokenService;
+
+    /**
+     * @InMemoryRepository application-oauth properties 정보를 담고 있음
+     * @getToken() 넘겨받은 code 로 Oauth 서버에 Token 요청
+     * @getUserProfile 첫 로그인 시 회원 가입
+     * 유저 인증 후 Jwt AccessToken 생성
+     */
+
+    @Transactional
+    @Override
+    public LoginResponseDto login(NaverOauthLoginParam params) {
+
+        ClientRegistration provider = inMemoryRepository.findByRegistrationId(params.provider());
+        log.info("redirect uri = {}", provider.getRedirectUri());
+        OauthTokenResponseDto tokenResponse = getToken(params.code(), provider, params.state());
+        log.info("OauthAccessToken = {}", tokenResponse.access_token());
+        User user = getUserProfile(params.provider(), tokenResponse, provider);
+
+        String accessToken = tokenService.generateToken(user.getUserEmail());
+        log.info("ServerAccessToken={}", accessToken);
+        return new LoginResponseDto(user.getUserEmail(), "BEARER_TYPE", accessToken);
+    }
+
+    private OauthTokenResponseDto getToken(String code, ClientRegistration provider, String state) {
+        return WebClient.create()
+                .post()
+                .uri(provider.getProviderDetails().getTokenUri())
+                .headers(header -> {
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(requestToken(code, provider, state))
+                .retrieve()
+                .bodyToMono(OauthTokenResponseDto.class)
+                .block();
+    }
+
+    private MultiValueMap<String, String> requestToken(String code, ClientRegistration provider, String state) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("client_id", provider.getClientId());
+        formData.add("state", state);
+        return formData;
+    }
+
+    private User getUserProfile(String providerName, OauthTokenResponseDto tokenResponse, ClientRegistration provider) {
+        Map<String, Object> userAttributes = getUserAttribute(provider, tokenResponse);
+        if (!providerName.equals("naver")) {
+            throw new RuntimeException("invalid provider name");
+        }
+
+        Oauth2UserInfo oauth2UserInfo = new NaverUserInfo(userAttributes);
+        if (oauth2UserInfo.getProvider() == null) {
+            throw new RuntimeException("provider is null");
+        }
+
+        String email = oauth2UserInfo.getEmail();
+        String nickname = oauth2UserInfo.getNickName();
+        String imageUrl = oauth2UserInfo.getImageUrl();
+        String ageRange = oauth2UserInfo.getAgeRange();
+        String oauth2Provider = oauth2UserInfo.getProvider();
+        String providerId = oauth2UserInfo.getProviderId();
+
+        log.info("ageRange={}", ageRange);
+        log.info("imageUrl={}", imageUrl);
+
+        Optional<User> optionalUser = userRepository.findById(email);
+
+        if (optionalUser.isEmpty()) {
+            User user = new User(email, nickname, imageUrl, ageRange, oauth2Provider, providerId);
+            userRepository.save(user);
+            return user;
+        } else {
+            return optionalUser.get();
+        }
+    }
+
+    private Map<String, Object> getUserAttribute(ClientRegistration provider, OauthTokenResponseDto tokenResponse) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(String.valueOf(tokenResponse.access_token())))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+    }
+}

--- a/src/main/java/fivestar/kTour/service/NaverOauthService.java
+++ b/src/main/java/fivestar/kTour/service/NaverOauthService.java
@@ -49,11 +49,11 @@ public class NaverOauthService implements OauthService<NaverOauthLoginParam> {
         log.info("redirect uri = {}", provider.getRedirectUri());
         OauthTokenResponseDto tokenResponse = getToken(params.code(), provider, params.state());
         log.info("OauthAccessToken = {}", tokenResponse.access_token());
-        User user = getUserProfile(params.provider(), tokenResponse, provider);
+        String email = getUserEmailFromNaver(params.provider(), tokenResponse, provider);
 
-        String accessToken = tokenService.generateToken(user.getUserEmail());
+        String accessToken = tokenService.generateToken(email);
         log.info("ServerAccessToken={}", accessToken);
-        return new LoginResponseDto(user.getUserEmail(), "BEARER_TYPE", accessToken);
+        return new LoginResponseDto(email, "BEARER_TYPE", accessToken);
     }
 
     private OauthTokenResponseDto getToken(String code, ClientRegistration provider, String state) {
@@ -81,7 +81,7 @@ public class NaverOauthService implements OauthService<NaverOauthLoginParam> {
         return formData;
     }
 
-    private User getUserProfile(String providerName, OauthTokenResponseDto tokenResponse, ClientRegistration provider) {
+    private String getUserEmailFromNaver(String providerName, OauthTokenResponseDto tokenResponse, ClientRegistration provider) {
         Map<String, Object> userAttributes = getUserAttribute(provider, tokenResponse);
         if (!providerName.equals("naver")) {
             throw new RuntimeException("invalid provider name");
@@ -107,10 +107,8 @@ public class NaverOauthService implements OauthService<NaverOauthLoginParam> {
         if (optionalUser.isEmpty()) {
             User user = new User(email, nickname, imageUrl, ageRange, oauth2Provider, providerId);
             userRepository.save(user);
-            return user;
-        } else {
-            return optionalUser.get();
         }
+        return email;
     }
 
     private Map<String, Object> getUserAttribute(ClientRegistration provider, OauthTokenResponseDto tokenResponse) {

--- a/src/main/java/fivestar/kTour/service/OauthService.java
+++ b/src/main/java/fivestar/kTour/service/OauthService.java
@@ -2,6 +2,6 @@ package fivestar.kTour.service;
 
 import fivestar.kTour.Dto.LoginResponseDto;
 
-public interface OauthService {
-    LoginResponseDto login(String providerName, String code);
+public interface OauthService<T> {
+    LoginResponseDto login(T params);
 }


### PR DESCRIPTION
- NaverOauthService 구현 및 테스팅 완료
- SNS 에서 코드 발급시 콜백 주소를 네이버는 http://localhost:8080/oauth/naver 카카오는 http://localhost:8080/oauth/kakao
- 컨트롤러에서 해당 콜백주소를 받도록 API 를 http://localhost:8080/oauth/{provider} -> @PathVariable 로 설계해 {provider} 값이 naver or kakao 에 따라 다른 OauthService 구현체로 비즈니스 로직이 수행되도록 구현
- 콜백 받고 로그인 수행시 카카오는 code, 네이버는 code, state 파라미터가 필수로 필요
- 둘의 매개변수가 달라 각각 따로 record 를 만들어줌 KakaoOauthLoginParam, NaverOauthLoginParam
- OauthService<T> 제네릭을 사용하도록 변경해서 login 메서드 매개변수를 T 로 받도록 변경 (인터페이스의 메서드 시그니처를 제네릭으로 사용)