### PR TITLE
PR : TokenService, JwtAuthFilter 기능에 맞게 리팩토링

### DIFF
--- a/src/main/java/fivestar/kTour/security/config/SecurityConfig.java
+++ b/src/main/java/fivestar/kTour/security/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .userDetailsService(jpaUserDetailsService)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .addFilterBefore(new JwtAuthFilter(tokenService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthFilter(tokenService, jpaUserDetailsService), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/src/main/java/fivestar/kTour/security/filter/JwtAuthFilter.java
+++ b/src/main/java/fivestar/kTour/security/filter/JwtAuthFilter.java
@@ -3,8 +3,11 @@ package fivestar.kTour.security.filter;
 import fivestar.kTour.security.service.TokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -19,12 +22,13 @@ import java.io.IOException;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final TokenService tokenService;
+    private final UserDetailsService jpaUserDetailsService;
 
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("request URL = {}", request.getRequestURI());
         log.info("Access Token Value = {}", request.getHeader("Authorization"));
 
-        String jwt = resolveToken(request);
+        String jwt = tokenService.resolveToken(request);
 
         if(StringUtils.hasText(jwt) && tokenService.isTokenValid(jwt)) {
             setAuthentication(tokenService.getEmailFromToken(jwt));
@@ -33,16 +37,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     }
 
     public void setAuthentication(String email) {
-        Authentication authentication = tokenService.createAuthentication(email);
+        UserDetails userDetails = jpaUserDetailsService.loadUserByUsername(email);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    // Request Header 에서 토큰 정보를 꺼내오기
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
     }
 }

--- a/src/main/java/fivestar/kTour/security/service/TokenService.java
+++ b/src/main/java/fivestar/kTour/security/service/TokenService.java
@@ -7,13 +7,11 @@ import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -27,7 +25,6 @@ public class TokenService {
     @Value("${jwt.secret}")
     private String secretKey;
     private Key key;
-    private final UserDetailsService jpaUserDetailsService;
 
     @PostConstruct
     public void init() {
@@ -47,9 +44,13 @@ public class TokenService {
                 .compact();
     }
 
-    public Authentication createAuthentication(String email) {
-        UserDetails userDetails = jpaUserDetailsService.loadUserByUsername(email);
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    // Request Header 에서 토큰 정보를 꺼내오기
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
     public boolean isTokenValid(String token) {


### PR DESCRIPTION
- 메서드가 일부 서비스에 맞지 않는것같아서 리팩토링해서 PR 보냅니다 :)
- resolveToken 메서드 (헤더 Authorization 에서 JWT를 Bearer 부분을 제거하고 꺼내는 기능) -> TokenService 로 이동
- 기존 TokenService 의 createAuthentication 메서드는 TokenService 와는 맞지 않는것으로 생각 (시큐리티 관련 기능)
- JwtAuthFilter 의 setAuthentication 메서드에 해당 메서드 기능을 합침
- 시큐리티 관련 기능이므로 JwtAuthFilter 에 있는것이 좀 더 적합한것으로 보입니다. 
- 기능 변경없는 리팩토링임으로 테스트 시 이상없음 확인~!